### PR TITLE
Use /usr/bin/env bash instead of /bin/bash

### DIFF
--- a/modules/boost/gcc/1.71.0/build.sh
+++ b/modules/boost/gcc/1.71.0/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build boost
 #

--- a/modules/cmake/gcc/3.15.2/build.sh
+++ b/modules/cmake/gcc/3.15.2/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build cmake
 #

--- a/modules/cuda-toolkit/10.1.243/build.sh
+++ b/modules/cuda-toolkit/10.1.243/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build cuda-toolkit
 #

--- a/modules/eigen/gcc/3.3.7/build.sh
+++ b/modules/eigen/gcc/3.3.7/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build eigen
 #

--- a/modules/fenics-dolfin/2019.1.0.post0/build.sh
+++ b/modules/fenics-dolfin/2019.1.0.post0/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build dolfin
 #

--- a/modules/fenics/2019.1.0/build.sh
+++ b/modules/fenics/2019.1.0/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build fenics
 #

--- a/modules/gmp/gcc/6.1.2/build.sh
+++ b/modules/gmp/gcc/6.1.2/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build gmp
 #

--- a/modules/gsl/gcc/2.6/build.sh
+++ b/modules/gsl/gcc/2.6/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build gsl
 #

--- a/modules/hdf5/gcc/1.10.5/build.sh
+++ b/modules/hdf5/gcc/1.10.5/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build hdf5
 #

--- a/modules/hwloc/gcc/2.0.4/build.sh
+++ b/modules/hwloc/gcc/2.0.4/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build hwloc
 #

--- a/modules/hypre/gcc/2.17.0/build.sh
+++ b/modules/hypre/gcc/2.17.0/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build hypre
 #

--- a/modules/iperf/gcc/2.0.13/build.sh
+++ b/modules/iperf/gcc/2.0.13/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build iperf
 #

--- a/modules/knem/gcc/1.1.3/build.sh
+++ b/modules/knem/gcc/1.1.3/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build knem
 #

--- a/modules/libevent/gcc/2.1.11-stable/build.sh
+++ b/modules/libevent/gcc/2.1.11-stable/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build libevent
 #

--- a/modules/libffi/gcc/3.2.1/build.sh
+++ b/modules/libffi/gcc/3.2.1/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build libffi
 #

--- a/modules/libtool/2.4.6/build.sh
+++ b/modules/libtool/2.4.6/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build libtool
 #

--- a/modules/metis/gcc/5.1.0/build.sh
+++ b/modules/metis/gcc/5.1.0/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build metis
 #

--- a/modules/mpfr/gcc/4.0.2/build.sh
+++ b/modules/mpfr/gcc/4.0.2/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build mpfr
 #

--- a/modules/mumps/gcc/5.2.1/build.sh
+++ b/modules/mumps/gcc/5.2.1/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build mumps
 #

--- a/modules/munge/gcc/0.5.13/build.sh
+++ b/modules/munge/gcc/0.5.13/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -e
+#!/usr/bin/env bash -e
 #
 # Build munge
 #

--- a/modules/numactl/gcc/2.0.12/build.sh
+++ b/modules/numactl/gcc/2.0.12/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build numactl
 #

--- a/modules/openblas/gcc/0.3.7/build.sh
+++ b/modules/openblas/gcc/0.3.7/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build openblas
 #

--- a/modules/openmpi/gcc/64/4.0.1/build.sh
+++ b/modules/openmpi/gcc/64/4.0.1/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build openmpi
 #

--- a/modules/openssl/gcc/1.1.1c/build.sh
+++ b/modules/openssl/gcc/1.1.1c/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build openssl
 #

--- a/modules/osu-micro-benchmarks/gcc/5.6.2/build.sh
+++ b/modules/osu-micro-benchmarks/gcc/5.6.2/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build osu-micro-benchmarks
 #

--- a/modules/parmetis/gcc/4.0.3/build.sh
+++ b/modules/parmetis/gcc/4.0.3/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build parmetis
 #

--- a/modules/patchelf/gcc/0.10/build.sh
+++ b/modules/patchelf/gcc/0.10/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build patchelf
 #

--- a/modules/petsc/gcc/3.11.3-cuda/build.sh
+++ b/modules/petsc/gcc/3.11.3-cuda/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build petsc
 #

--- a/modules/petsc/gcc/3.11.3/build.sh
+++ b/modules/petsc/gcc/3.11.3/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build petsc
 #

--- a/modules/pmix/gcc/3.1.4/build.sh
+++ b/modules/pmix/gcc/3.1.4/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build pmix
 #

--- a/modules/pybind11/gcc/2.3.0/build.sh
+++ b/modules/pybind11/gcc/2.3.0/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build pybind11
 #

--- a/modules/python/gcc/3.7.4/build.sh
+++ b/modules/python/gcc/3.7.4/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build python
 #

--- a/modules/python3.7/fenics-dijitso/2019.1.0/build.sh
+++ b/modules/python3.7/fenics-dijitso/2019.1.0/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build fenics-dijitso
 #

--- a/modules/python3.7/fenics-ffc/2019.1.0/build.sh
+++ b/modules/python3.7/fenics-ffc/2019.1.0/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build fenics-ffc
 #

--- a/modules/python3.7/fenics-fiat/2019.1.0/build.sh
+++ b/modules/python3.7/fenics-fiat/2019.1.0/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build fenics-fiat
 #

--- a/modules/python3.7/fenics-ufl/2019.1.0/build.sh
+++ b/modules/python3.7/fenics-ufl/2019.1.0/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build fenics-ufl
 #

--- a/modules/python3.7/fenics/2019.1.0.post0/build.sh
+++ b/modules/python3.7/fenics/2019.1.0.post0/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build fenics
 #

--- a/modules/python3.7/matplotlib/3.1.1/build.sh
+++ b/modules/python3.7/matplotlib/3.1.1/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build matplotlib
 #

--- a/modules/python3.7/mpi4py/3.0.2/build.sh
+++ b/modules/python3.7/mpi4py/3.0.2/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build mpi4py
 #

--- a/modules/python3.7/mpmath/1.1.0/build.sh
+++ b/modules/python3.7/mpmath/1.1.0/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build mpmath
 #

--- a/modules/python3.7/numpy/1.17.0/build.sh
+++ b/modules/python3.7/numpy/1.17.0/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build numpy
 #

--- a/modules/python3.7/petsc4py/3.11.0/build.sh
+++ b/modules/python3.7/petsc4py/3.11.0/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build petsc4py
 #

--- a/modules/python3.7/pkgconfig/1.5.1/build.sh
+++ b/modules/python3.7/pkgconfig/1.5.1/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build pkgconfig
 #

--- a/modules/python3.7/ply/3.11/build.sh
+++ b/modules/python3.7/ply/3.11/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build ply
 #

--- a/modules/python3.7/pytest/5.1.0/build.sh
+++ b/modules/python3.7/pytest/5.1.0/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build pytest
 #

--- a/modules/python3.7/sympy/1.4/build.sh
+++ b/modules/python3.7/sympy/1.4/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build sympy
 #

--- a/modules/qperf/gcc/0.4.11/build.sh
+++ b/modules/qperf/gcc/0.4.11/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build qperf
 #

--- a/modules/scalapack/gcc/2.0.2/build.sh
+++ b/modules/scalapack/gcc/2.0.2/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build scalapack
 #

--- a/modules/scotch/gcc/6.0.7/build.sh
+++ b/modules/scotch/gcc/6.0.7/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build scotch
 #

--- a/modules/slurm/19.05.2/build.sh
+++ b/modules/slurm/19.05.2/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build slurm
 #

--- a/modules/suitesparse/gcc/5.4.0/build.sh
+++ b/modules/suitesparse/gcc/5.4.0/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build suitesparse
 #

--- a/modules/superlu/gcc/5.2.1/build.sh
+++ b/modules/superlu/gcc/5.2.1/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build superlu
 #

--- a/modules/superlu_dist/gcc/6.1.1/build.sh
+++ b/modules/superlu_dist/gcc/6.1.1/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build superlu_dist
 #

--- a/modules/ucx/gcc/1.6.0/build.sh
+++ b/modules/ucx/gcc/1.6.0/build.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -xe
+#!/usr/bin/env bash -xe
 #
 # Build ucx
 #


### PR DESCRIPTION
This allows the use of non-system bash, which is particularly useful on
macOS, where the bash version is outdated.