### PR TITLE
Always interpret the install prefix as a directory

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -62,7 +62,7 @@ function parse_command_line_args() {
 	case "${1}" in
 	    -h | --help) help; exit 0;;
 	    --list-modules) list_modules=1; shift 1;;
-            --prefix=*) prefix=$(realpath "${1#*=}")/; shift 1;;
+	    --prefix=*) prefix=$(realpath "${1#*=}")/; shift 1;;
 	    --modulefilesdir=*) modulefilesdir="${1#*=}"; shift 1;;
 	    --build-dependencies) build_dependencies=missing-only; shift 1;;
             --build-dependencies=*) build_dependencies="${1#*=}"; shift 1;;

--- a/build.sh
+++ b/build.sh
@@ -62,7 +62,7 @@ function parse_command_line_args() {
 	case "${1}" in
 	    -h | --help) help; exit 0;;
 	    --list-modules) list_modules=1; shift 1;;
-	    --prefix=*) prefix="${1#*=}"; shift 1;;
+            --prefix=*) prefix=$(realpath "${1#*=}")/; shift 1;;
 	    --modulefilesdir=*) modulefilesdir="${1#*=}"; shift 1;;
 	    --build-dependencies) build_dependencies=missing-only; shift 1;;
             --build-dependencies=*) build_dependencies="${1#*=}"; shift 1;;


### PR DESCRIPTION
I had some accidents where running e.g. 
```
./build.sh --prefix=$HOME/testmodules --build-dependencies hwloc/2.0.4
```
would install hwloc to `$HOME/testmoduleshwloc`. I believe this command used to install hwloc to `$HOME/testmodules/hwloc` 

The top level build.sh script will now interpret the prefix as a directory, ending with a `/`.
It might not be the cleanest solution, but it does at least fix this for the top level build script.